### PR TITLE
Releasing v1.1.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 == Changelog ==
+= 1.1.1 =
+Release Date: 2016-09-15
+
+* Fixed missing bug that was breaking the plugin on some environments.
+
 = 1.1.0 =
 Release Date: 2016-09-14
 

--- a/embedpress.php
+++ b/embedpress.php
@@ -13,7 +13,7 @@
  * Plugin Name: EmbedPress
  * Plugin URI:  http://pressshack.com/embedpress/
  * Description: EmbedPress lets you embed anything in WordPress! Also, you can enhance their uniqueness by passing custom parameters to each one of them.
- * Version:     1.1.0
+ * Version:     1.1.1
  * Author:      PressShack
  * Author URI:  http://pressshack.com/
 */

--- a/includes.php
+++ b/includes.php
@@ -16,7 +16,7 @@ if (!defined('EMBEDPRESS_PLG_NAME')) {
 }
 
 if (!defined('EMBEDPRESS_PLG_VERSION')) {
-    define('EMBEDPRESS_PLG_VERSION', "1.1.0");
+    define('EMBEDPRESS_PLG_VERSION', "1.1.1");
 }
 
 if (!defined('EMBEDPRESS_PATH_BASE')) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PressShack
 Tags: embed, embera, embedding, pressshack, ostraining
 Requires at least: 4.0
 Tested up to: 4.6.1
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,6 +51,11 @@ There're two ways to install EmbedPress plugin:
 `
 
 == Changelog ==
+= 1.1.1 =
+Release Date: 2016-09-15
+
+* Fixed missing bug that was breaking the plugin on some environments.
+
 = 1.1.0 =
 Release Date: 2016-09-14
 


### PR DESCRIPTION
Fixed a bug that was breaking the plugin on some environments due to case-sensitiveness. 
Now the plugin's name will ALWAYS be assumed/treated as lowercased, since thats how WordPress handles it.
